### PR TITLE
Setup Autosign.conf

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,6 +12,7 @@ class puppet (
 
   # Server
   Optional[Array[String]]                      $dns_alt_names         = $::puppet::params::dns_alt_names,
+  Optional[Array]                              $autosign              = $::puppet::params::autosign,
   Optional[Hash[String, Hash[String, String]]] $fileserver_conf       = $::puppet::params::fileserver_conf,
   Boolean                                      $manage_hiera          = $::puppet::params::manage_hiera,
   Optional[Pattern[/\Apuppet/]]                $hiera_source          = $::puppet::params::hiera_source,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,6 +10,7 @@ class puppet::params {
   $puppetmaster = "puppet.${::domain}"
 
   $dns_alt_names = undef
+  $autosign = undef
   $fileserver_conf = undef
   $manage_hiera = true
   $hiera_source = undef

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -1,6 +1,7 @@
 # document me
 class puppet::server::config (
   $ca_enabled            = $::puppet::server_ca_enabled,
+  $autosign              = $::puppet::autosign,
   $config_dir            = $::puppet::params::server_config_dir,
   $fileserver            = $::puppet::fileserver_conf,
   $manage_hiera          = $::puppet::manage_hiera,
@@ -124,6 +125,14 @@ class puppet::server::config (
     # - $puppetdb_server
     file { '/etc/puppetlabs/puppet/puppetdb.conf':
       content => template('puppet/server/puppetdb.conf.erb'),
+    }
+  }
+
+  if ( $server and $autosign ) {
+    # Template autosign.conf
+    # - $autosign
+    file { '/etc/puppetlabs/puppet/autosign.conf':
+      content => template('puppet/server/autosign.conf.erb'),
     }
   }
 

--- a/spec/classes/puppet_server_config_spec.rb
+++ b/spec/classes/puppet_server_config_spec.rb
@@ -105,6 +105,11 @@ describe 'puppet::server::config', :type => :class do
       it { should contain_concat__fragment('puppet_master').with(:content => /reports = puppetdb, hipchat/) }
     end
 
+    context 'with autosign' do
+      let(:pre_condition) { 'class { "puppet": server => true, autosign => ["test.domain"] }'}
+      it { should contain_file('/etc/puppetlabs/puppet/autosign.conf').with(:content => /test\.domain/) }
+    end
+
     context 'with firewall' do
       let(:pre_condition) { 'class { "puppet": server => true, firewall => true }' }
       it { should contain_firewall('500 allow inbound connections to puppetserver') }

--- a/templates/server/autosign.conf.erb
+++ b/templates/server/autosign.conf.erb
@@ -1,0 +1,3 @@
+<% @autosign.each do |line| -%>
+<%= line %>
+<% end -%>


### PR DESCRIPTION
Adds a paramter, `autosign` which is an array of domains/patterns to autosign. Uses that if present to write an autosign.conf. 

