### PR TITLE
Update for 2.3.0

### DIFF
--- a/templates/server/bootstrap.cfg.erb
+++ b/templates/server/bootstrap.cfg.erb
@@ -10,6 +10,7 @@ puppetlabs.services.master.master-service/master-service
 puppetlabs.services.puppet-admin.puppet-admin-service/puppet-admin-service
 puppetlabs.services.legacy-routes.legacy-routes-service/legacy-routes-service
 puppetlabs.trapperkeeper.services.authorization.authorization-service/authorization-service
+puppetlabs.services.versioned-code-service.versioned-code-service/versioned-code-service
 <% if @ca_enabled -%>
 puppetlabs.services.ca.certificate-authority-service/certificate-authority-service
 <% else -%>


### PR DESCRIPTION
See http://docs.puppetlabs.com/puppetserver/latest/release_notes.html#modifications-to-bootstrapcfg-might-cause-problems-during-upgrades-to-230 for more detail.

This will need a release ASAP as the current version, when using latest or 2.3.0, will result in puppetserver being reloaded and failing to start.