### PR TITLE
Update concat dep, fix puppetserver 2.3 and remove deprecated java

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -20,7 +20,7 @@ A puppet module to manage puppet-agent and puppetserver (the closure server, not
 
 ## Module Description
 
-This is a puppet module to manage puppet >= 4.0.0 and puppetserver >= 2.0.0.
+This is a puppet module to manage puppet >= 4.0.0 and puppetserver >= 2.3.0.
 
 Currently acceptance tests are a bit wonky due to beaker's inability to handle puppet AIO packages
 
@@ -178,7 +178,7 @@ Default: undef
 #####`server_java_opts`
 String.  Java options for puppet server
 
-Default: -Xms2g -Xmx2g -XX:MaxPermSize=256m
+Default: -Xms2g -Xmx2g 
 
 #####`server_log_dir`
 String.  Location of puppetserver logs

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,7 +21,7 @@ class puppet::params {
   $runinterval = '30m'
   $server_ca_enabled = true
   $server_certname = undef
-  $server_java_opts = '-Xms2g -Xmx2g -XX:MaxPermSize=256m'
+  $server_java_opts = '-Xms2g -Xmx2g'
   $server_log_dir = '/var/log/puppetlabs/puppetserver'
   $server_log_file = 'puppetserver.log'
   $server_reports = undef

--- a/metadata.json
+++ b/metadata.json
@@ -29,7 +29,7 @@
     }
   ],
   "dependencies": [
-    { "name": "puppetlabs/concat", "version_requirement": ">= 1.1.0 <2.0.0" },
+    { "name": "puppetlabs/concat", "version_requirement": ">= 1.1.0 <3.0.0" },
     { "name": "puppetlabs/stdlib", "version_requirement": ">=4.2.0 <5.0.0" },
     { "name": "puppetlabs/firewall", "version_requirement": ">= 1.2.0 <2.0.0" }
   ]

--- a/templates/server/bootstrap.cfg.erb
+++ b/templates/server/bootstrap.cfg.erb
@@ -10,6 +10,7 @@ puppetlabs.services.master.master-service/master-service
 puppetlabs.services.puppet-admin.puppet-admin-service/puppet-admin-service
 puppetlabs.services.legacy-routes.legacy-routes-service/legacy-routes-service
 puppetlabs.trapperkeeper.services.authorization.authorization-service/authorization-service
+puppetlabs.services.versioned-code-service.versioned-code-service/versioned-code-service
 <% if @ca_enabled -%>
 puppetlabs.services.ca.certificate-authority-service/certificate-authority-service
 <% else -%>


### PR DESCRIPTION
Fixed PR with single commit.

* semver check for concat < 3.0
* remove deprecated java MaxPermSize parameter (can fail on some systemd systems confused on warning)
* Add required bootstrap.cfg stanza for puppetserver 2.3.x compatibility. (since module defaults to "latest"

Thanks!