### PR TITLE
Server 2.6 support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,8 @@ group :unit_tests do
   gem 'rake',                                              :require => false
   gem 'rspec', '~> 3.1.0',                                 :require => false
   gem 'rspec-puppet',                                      :require => false
-  gem 'puppetlabs_spec_helper',                            :require => false
-  gem 'puppet-lint',                                       :require => false
+  gem 'puppetlabs_spec_helper', '~> 0.0',                  :require => false
+  gem 'puppet-lint', '~> 1.0',                             :require => false
   gem 'puppet-syntax',                                     :require => false
   gem 'metadata-json-lint',                                :require => false
   gem 'json',                                              :require => false

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,6 +21,7 @@ class puppet (
   String                                       $puppetdb_version      = $::puppet::params::puppetdb_version,
   Boolean                                      $manage_puppetdb       = $::puppet::params::manage_puppetdb,
   String                                       $runinterval           = $::puppet::params::runinterval,
+  String                                       $server_bootstrap_dir  = $::puppet::params::server_bootstrap_dir,
   Boolean                                      $server_ca_enabled     = $::puppet::params::server_ca_enabled,
   Optional[String]                             $server_certname       = $::puppet::params::server_certname,
   String                                       $server_java_opts      = $::puppet::params::server_java_opts,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,6 +21,7 @@ class puppet::params {
   $runinterval = '30m'
   $server_ca_enabled = true
   $server_certname = undef
+  $server_bootstrap_dir = '/etc/puppetlabs/puppetserver/bootstrap.cfg'
   $server_java_opts = '-Xms2g -Xmx2g'
   $server_log_dir = '/var/log/puppetlabs/puppetserver'
   $server_log_file = 'puppetserver.log'

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -6,9 +6,11 @@ class puppet::server::config (
   $manage_hiera          = $::puppet::manage_hiera,
   $hiera_source          = $::puppet::hiera_source,
   $java_opts             = $::puppet::server_java_opts,
+  $bootstrap_dir         = $::puppet::server_bootstrap_dir,
   $log_dir               = $::puppet::server_log_dir,
   $log_file              = $::puppet::server_log_file,
   $server                = $::puppet::server,
+  $server_version        = $::puppet::server_version,
   $runinterval           = $::puppet::runinterval,
   $puppetdb              = $::puppet::puppetdb,
   $puppetdb_port         = $::puppet::puppetdb_port,
@@ -36,6 +38,19 @@ class puppet::server::config (
     group  => 'puppet',
   }
 
+  case $server_version {
+    /(\d+\.\d+)\.\d+\-\d+.*/: {
+      $config_version = 0 + $1 # This must be a float 
+    }
+    'latest': {
+      # There is a breaking confign change for version 2.6 and later.
+      $config_version = 2.6
+    }
+    default: {
+      $config_version = 2.5
+    }
+  }
+
   if $server {
     file { $log_dir:
       ensure => 'directory',
@@ -54,6 +69,7 @@ class puppet::server::config (
   }
 
   # Template uses
+  # - $
   # - $java_opts
   file { "${config_dir}/puppetserver":
     content => template("${module_name}/server/puppetserver.sysconfig.erb"),

--- a/spec/classes/puppet_server_config_spec.rb
+++ b/spec/classes/puppet_server_config_spec.rb
@@ -7,7 +7,7 @@ describe 'puppet::server::config', :type => :class do
     let(:pre_condition) { 'class { "puppet": }' }
 
     it { should_not contain_concat__fragment('puppet_master') }
-    it { should contain_file('/etc/puppetlabs/puppetserver/bootstrap.cfg').with(:ensure => 'absent') }
+    it { should contain_file('/opt/puppetlabs/server/apps/puppetserver/config/services.d/bootstrap.cfg').with(:ensure => 'absent') }
     it { should contain_file('/etc/puppetlabs/puppetserver/logback.xml').with(:ensure => 'absent') }
     it { should contain_file('/etc/puppetlabs/puppetserver/conf.d/ca.conf').with(:ensure => 'absent') }
     it { should contain_file('/etc/puppetlabs/puppetserver/conf.d/global.conf').with(:ensure => 'absent') }
@@ -39,8 +39,6 @@ describe 'puppet::server::config', :type => :class do
       it { should_not contain_concat__fragment('puppet_master').with(:content => /reports/) }
       it { should_not contain_concat__fragment('puppet_master').with( :content => /dns_alt_names/ ) }
       it { should_not contain_concat__fragment('puppet_master').with(:content => /storeconfigs/) }
-      it { should contain_file('/etc/puppetlabs/puppetserver/bootstrap.cfg').with(:content => /puppetlabs\.services\.ca\.certificate\-authority\-service\/certificate\-authority\-service/) }
-      it { should_not contain_file('/etc/puppetlabs/puppetserver/bootstrap.cfg').with(:content => /puppetlabs\.services\.ca\.certificate\-authority\-disabled\-service\/certificate\-authority\-disabled\-service/) }
       it { should contain_file('/etc/puppetlabs/puppetserver/logback.xml').with(:content => /<file>\/var\/log\/puppetlabs\/puppetserver\/puppetserver\.log<\/file>/) }
       it { should contain_file('/etc/puppetlabs/puppetserver/request-logging.xml') }
       it { should contain_file('/etc/puppetlabs/puppetserver/conf.d/ca.conf') }
@@ -55,21 +53,33 @@ describe 'puppet::server::config', :type => :class do
     context 'puppetserver 2.5 or earlier debian' do
       let(:pre_condition) { 'class { "puppet": server => true, server_version => "2.4.0-1puppetlabs1"}' }
       it { should contain_file('/etc/puppetlabs/puppetserver/conf.d/web-routes.conf').without(:content => /puppetlabs\.trapperkeeper\.services\.status\.status\-service\/status\-service/ ) }
+      it { should contain_file('/etc/puppetlabs/puppetserver/bootstrap.cfg').without(:content => /puppetlabs\.trapperkeeper\.services\.status\.status\-service\/status\-service/)}
+      it { should contain_file('/etc/puppetlabs/puppetserver/bootstrap.cfg').with(:content => /puppetlabs\.services\.ca\.certificate\-authority\-service\/certificate\-authority\-service/) }
+      it { should_not contain_file('/etc/puppetlabs/puppetserver/bootstrap.cfg').with(:content => /puppetlabs\.services\.ca\.certificate\-authority\-disabled\-service\/certificate\-authority\-disabled\-service/) }
     end
 
     context 'puppetserver 2.5 or earlier redhat' do
       let(:pre_condition) { 'class { "puppet": server => true, server_version => "2.3.1-1.el7"}' }
       it { should contain_file('/etc/puppetlabs/puppetserver/conf.d/web-routes.conf').without(:content => /puppetlabs\.trapperkeeper\.services\.status\.status\-service\/status\-service/ ) }
+      it { should contain_file('/etc/puppetlabs/puppetserver/bootstrap.cfg').without(:content => /puppetlabs\.trapperkeeper\.services\.status\.status\-service\/status\-service/) }
+      it { should contain_file('/etc/puppetlabs/puppetserver/bootstrap.cfg').with(:content => /puppetlabs\.services\.ca\.certificate\-authority\-service\/certificate\-authority\-service/) }
+      it { should_not contain_file('/etc/puppetlabs/puppetserver/bootstrap.cfg').with(:content => /puppetlabs\.services\.ca\.certificate\-authority\-disabled\-service\/certificate\-authority\-disabled\-service/) }
     end
 
     context 'puppetserver 2.6 or later ' do
       let(:pre_condition) { 'class { "puppet": server => true, server_version => "2.8.1-1.el7"}' }
       it { should contain_file('/etc/puppetlabs/puppetserver/conf.d/web-routes.conf').with(:content => /puppetlabs\.trapperkeeper\.services\.status\.status\-service\/status\-service/ ) }
+      it { should contain_file('/opt/puppetlabs/server/apps/puppetserver/config/services.d/bootstrap.cfg').with(:content => /puppetlabs\.trapperkeeper\.services\.status\.status\-service\/status\-service/ ) }
+      it { should contain_file('/opt/puppetlabs/server/apps/puppetserver/config/services.d/bootstrap.cfg').with(:content => /puppetlabs\.services\.ca\.certificate\-authority\-service\/certificate\-authority\-service/) }
+      it { should_not contain_file('/opt/puppetlabs/server/apps/puppetserver/config/services.d/bootstrap.cfg').with(:content => /puppetlabs\.services\.ca\.certificate\-authority\-disabled\-service\/certificate\-authority\-disabled\-service/) }
     end
 
     context 'latest server on new install' do
       let(:pre_condition) { 'class { "puppet": server => true}' }
       it { should contain_file('/etc/puppetlabs/puppetserver/conf.d/web-routes.conf').with(:content => /puppetlabs\.trapperkeeper\.services\.status\.status\-service\/status\-service/ ) }
+      it { should contain_file('/opt/puppetlabs/server/apps/puppetserver/config/services.d/bootstrap.cfg').with(:content => /puppetlabs\.trapperkeeper\.services\.status\.status\-service\/status\-service/ ) }
+      it { should contain_file('/opt/puppetlabs/server/apps/puppetserver/config/services.d/bootstrap.cfg').with(:content => /puppetlabs\.services\.ca\.certificate\-authority\-service\/certificate\-authority\-service/) }
+      it { should_not contain_file('/opt/puppetlabs/server/apps/puppetserver/config/services.d/bootstrap.cfg').with(:content => /puppetlabs\.services\.ca\.certificate\-authority\-disabled\-service\/certificate\-authority\-disabled\-service/) }
     end
 
     context 'redhat' do
@@ -95,8 +105,8 @@ describe 'puppet::server::config', :type => :class do
 
     context 'set disable ca' do
       let(:pre_condition) { 'class { "puppet": server => true, server_ca_enabled => false }'}
-      it { should_not contain_file('/etc/puppetlabs/puppetserver/bootstrap.cfg').with(:content => /puppetlabs\.services\.ca\.certificate\-authority\-service\/certificate\-authority\-service/) }
-      it { should contain_file('/etc/puppetlabs/puppetserver/bootstrap.cfg').with(:content => /puppetlabs\.services\.ca\.certificate\-authority\-disabled\-service\/certificate\-authority\-disabled\-service/) }
+      it { should_not contain_file('/opt/puppetlabs/server/apps/puppetserver/config/services.d/bootstrap.cfg').with(:content => /puppetlabs\.services\.ca\.certificate\-authority\-service\/certificate\-authority\-service/) }
+      it { should contain_file('/opt/puppetlabs/server/apps/puppetserver/config/services.d/bootstrap.cfg').with(:content => /puppetlabs\.services\.ca\.certificate\-authority\-disabled\-service\/certificate\-authority\-disabled\-service/) }
       it { should contain_concat__fragment('puppet_master').with(:content => /ca = false/) }
     end
 

--- a/spec/classes/puppet_server_config_spec.rb
+++ b/spec/classes/puppet_server_config_spec.rb
@@ -48,9 +48,28 @@ describe 'puppet::server::config', :type => :class do
       it { should contain_file('/etc/puppetlabs/puppetserver/conf.d/puppetserver.conf').with( :content => /max-active-instances: 3/ ) }
       it { should contain_file('/etc/puppetlabs/puppetserver/conf.d/puppetserver.conf').with( :content => /use-legacy-auth-conf: false/ ) }
       it { should contain_file('/etc/puppetlabs/puppetserver/conf.d/web-routes.conf') }
-      it { should contain_file('/etc/puppetlabs/puppetserver/conf.d/webserver.conf') }
       it { should contain_file('/etc/puppetlabs/code/hiera.yaml').with(:ensure => 'absent') }
       it { should_not contain_firewall('500 allow inbound connections to puppetserver') }
+    end
+
+    context 'puppetserver 2.5 or earlier debian' do
+      let(:pre_condition) { 'class { "puppet": server => true, server_version => "2.4.0-1puppetlabs1"}' }
+      it { should contain_file('/etc/puppetlabs/puppetserver/conf.d/web-routes.conf').without(:content => /puppetlabs\.trapperkeeper\.services\.status\.status\-service\/status\-service/ ) }
+    end
+
+    context 'puppetserver 2.5 or earlier redhat' do
+      let(:pre_condition) { 'class { "puppet": server => true, server_version => "2.3.1-1.el7"}' }
+      it { should contain_file('/etc/puppetlabs/puppetserver/conf.d/web-routes.conf').without(:content => /puppetlabs\.trapperkeeper\.services\.status\.status\-service\/status\-service/ ) }
+    end
+
+    context 'puppetserver 2.6 or later ' do
+      let(:pre_condition) { 'class { "puppet": server => true, server_version => "2.8.1-1.el7"}' }
+      it { should contain_file('/etc/puppetlabs/puppetserver/conf.d/web-routes.conf').with(:content => /puppetlabs\.trapperkeeper\.services\.status\.status\-service\/status\-service/ ) }
+    end
+
+    context 'latest server on new install' do
+      let(:pre_condition) { 'class { "puppet": server => true}' }
+      it { should contain_file('/etc/puppetlabs/puppetserver/conf.d/web-routes.conf').with(:content => /puppetlabs\.trapperkeeper\.services\.status\.status\-service\/status\-service/ ) }
     end
 
     context 'redhat' do
@@ -62,6 +81,11 @@ describe 'puppet::server::config', :type => :class do
       let(:facts) { { :concat_basedir => '/var/lib/puppet/concat', :domain => 'example.com', :osfamily => 'Debian', :id => '0', :path => '/bin', :kernel => 'Linux' } }
       let(:pre_condition) { 'class { "puppet": server => true}' }
       it { should contain_file('/etc/default/puppetserver') }
+    end
+
+    context 'set bootstrap dir' do
+      let(:pre_condition) { 'class { "puppet": server => true, server_bootstrap_dir => "blah" }'}
+      it { should contain_file('/etc/sysconfig/puppetserver').with(:content => /BOOTSTRAP_CONFIG="blah"/) }
     end
 
     context 'set java opts' do

--- a/templates/server/bootstrap.cfg.erb
+++ b/templates/server/bootstrap.cfg.erb
@@ -16,3 +16,8 @@ puppetlabs.services.ca.certificate-authority-service/certificate-authority-servi
 <% else -%>
 puppetlabs.services.ca.certificate-authority-disabled-service/certificate-authority-disabled-service
 <% end -%>
+<% if @config >= 2.6 -%>
+puppetlabs.services.jruby-pool-manager.jruby-pool-manager-service/jruby-pool-manager-service
+puppetlabs.trapperkeeper.services.scheduler.scheduler-service/scheduler-service
+puppetlabs.trapperkeeper.services.status.status-service/status-service
+<% end -%>

--- a/templates/server/puppetserver.sysconfig.erb
+++ b/templates/server/puppetserver.sysconfig.erb
@@ -5,7 +5,7 @@ JAVA_ARGS="<%= @java_opts %>"
 INSTALL_DIR="/opt/puppetlabs/server/apps/puppetserver"
 JARFILE="server/apps/puppetserver/puppet-server-release.jar"
 CONFIG="/etc/puppetlabs/puppetserver/conf.d"
-BOOTSTRAP_CONFIG="/etc/puppetlabs/puppetserver/bootstrap.cfg"
+BOOTSTRAP_CONFIG="<%= @bootstrap_dir %>"
 USER="puppet"
 GROUP="puppet"
 SERVICE_STOP_RETRIES=60

--- a/templates/server/puppetserver.sysconfig.erb
+++ b/templates/server/puppetserver.sysconfig.erb
@@ -5,7 +5,7 @@ JAVA_ARGS="<%= @java_opts %>"
 INSTALL_DIR="/opt/puppetlabs/server/apps/puppetserver"
 JARFILE="server/apps/puppetserver/puppet-server-release.jar"
 CONFIG="/etc/puppetlabs/puppetserver/conf.d"
-BOOTSTRAP_CONFIG="<%= @bootstrap_dir %>"
+BOOTSTRAP_CONFIG="<%= @parsed_bootstrap_dir %>"
 USER="puppet"
 GROUP="puppet"
 SERVICE_STOP_RETRIES=60

--- a/templates/server/web-routes.conf.erb
+++ b/templates/server/web-routes.conf.erb
@@ -9,4 +9,12 @@ web-router-service: {
 
     # This controls the mount point for the puppet admin API.
     "puppetlabs.services.puppet-admin.puppet-admin-service/puppet-admin-service": "/puppet-admin-api"
+
+<%  if @config_version >= 2.6  %>
+    # This controls the mount point for the status API
+    "puppetlabs.trapperkeeper.services.status.status-service/status-service": "/status"
+<%  end  %>
+
+<%= @config_version %>
+
 }

--- a/templates/server/web-routes.conf.erb
+++ b/templates/server/web-routes.conf.erb
@@ -10,11 +10,11 @@ web-router-service: {
     # This controls the mount point for the puppet admin API.
     "puppetlabs.services.puppet-admin.puppet-admin-service/puppet-admin-service": "/puppet-admin-api"
 
-<%  if @config_version >= 2.6  %>
+<%  if @config >= 2.6  %>
     # This controls the mount point for the status API
     "puppetlabs.trapperkeeper.services.status.status-service/status-service": "/status"
 <%  end  %>
 
-<%= @config_version %>
+<%= @config %>
 
 }

--- a/templates/server/web-routes.conf.erb
+++ b/templates/server/web-routes.conf.erb
@@ -15,6 +15,4 @@ web-router-service: {
     "puppetlabs.trapperkeeper.services.status.status-service/status-service": "/status"
 <%  end  %>
 
-<%= @config %>
-
 }


### PR DESCRIPTION
Howdy,

Fixes - https://github.com/jlambert121/jlambert121-puppet/issues/67

I've added support for the changes in puppetserver 2.6.  
- added new parameter server_bootstrap_dir that takes a string for the location of the bootstrap file.
- added status service information to web-routes.conf and bootstrap.cfg for version >2.6

There are several new unit tests for my changes and the integration tests pass for server.  

I did not touch the metadata.json file or the README file.

Notes:
- due to a change in puppet version 4.4 the agent integration test now fails.  
- The default version of puppetserver is now 2.6.
