### PR TITLE
Basic support for autosign

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -36,6 +36,10 @@ class puppet (
   Optional[String]                             $server_ssl_ca_cert    = $::puppet::params::server_ssl_ca_cert,
   Optional[String]                             $server_ssl_cert_chain = $::puppet::params::server_ssl_cert_chain,
   Optional[String]                             $server_ssl_crl_path   = $::puppet::params::server_ssl_crl_path,
+  Optional[String]                             $autosign              = $::puppet::params::autosign,
+  Optional[String]                             $autosign_method       = $::puppet::params::autosign_method,
+  Optional[String]                             $autosign_file         = $::puppet::params::autosign_file,
+  Optional[Array[String]]                      $autosign_white_list   = $::puppet::params::autosign_white_list
 ) inherits puppet::params {
 
   if $puppetdb and !$puppetdb_server {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -36,7 +36,7 @@ class puppet (
   Optional[String]                             $server_ssl_ca_cert    = $::puppet::params::server_ssl_ca_cert,
   Optional[String]                             $server_ssl_cert_chain = $::puppet::params::server_ssl_cert_chain,
   Optional[String]                             $server_ssl_crl_path   = $::puppet::params::server_ssl_crl_path,
-  Optional[String]                             $autosign              = $::puppet::params::autosign,
+  Boolean                                      $autosign              = $::puppet::params::autosign,
   Optional[String]                             $autosign_method       = $::puppet::params::autosign_method,
   Optional[String]                             $autosign_file         = $::puppet::params::autosign_file,
   Optional[Array[String]]                      $autosign_white_list   = $::puppet::params::autosign_white_list

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -36,7 +36,7 @@ class puppet::params {
   $server_ssl_crl_path = undef
   $autosign = false
   $autosign_method = 'file'
-  $autosign_file = undef
+  $autosign_file = '/etc/puppetlabs/puppet/autosign.conf'
   $autosign_white_list = []
 
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -37,7 +37,7 @@ class puppet::params {
   $autosign = false
   $autosign_method = 'file'
   $autosign_file = '/etc/puppetlabs/puppet/autosign.conf'
-  $autosign_white_list = []
+  $autosign_white_list = [ ]
 
 
   case $::osfamily {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -34,6 +34,10 @@ class puppet::params {
   $server_ssl_ca_cert = undef
   $server_ssl_cert_chain = undef
   $server_ssl_crl_path = undef
+  $autosign = false
+  $autosign_method = 'file'
+  $autosign_file = undef
+  $autosign_white_list = []
 
 
   case $::osfamily {

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -23,6 +23,9 @@ class puppet::server::config (
   $server_ssl_ca_cert    = $::puppet::server_ssl_ca_cert,
   $server_ssl_cert_chain = $::puppet::server_ssl_cert_chain,
   $server_ssl_crl_path   = $::puppet::server_ssl_crl_path,
+  $autosign              = $::puppet::autosign,
+  $autosign_method       = $::puppet::autosign_method,
+  $autosign_file         = $::puppet::autosign_file
 ) {
 
   $file_ensure = $server ? {
@@ -124,6 +127,13 @@ class puppet::server::config (
     # - $puppetdb_server
     file { '/etc/puppetlabs/puppet/puppetdb.conf':
       content => template('puppet/server/puppetdb.conf.erb'),
+    }
+  }
+
+  ##
+  if( $server and $autosign and $autosign_method == 'file') {
+    file { '/etc/puppetlabs/puppet/autosign.conf':
+      content => template("${module_name}/autosign.conf.erb")
     }
   }
 

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -25,7 +25,8 @@ class puppet::server::config (
   $server_ssl_crl_path   = $::puppet::server_ssl_crl_path,
   $autosign              = $::puppet::autosign,
   $autosign_method       = $::puppet::autosign_method,
-  $autosign_file         = $::puppet::autosign_file
+  $autosign_file         = $::puppet::autosign_file,
+  $autosign_white_list   = $::puppet::autosign_white_list
 ) {
 
   $file_ensure = $server ? {

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -133,7 +133,7 @@ class puppet::server::config (
   ##
   if( $server and $autosign and $autosign_method == 'file') {
     file { '/etc/puppetlabs/puppet/autosign.conf':
-      content => template("${module_name}/autosign.conf.erb")
+      content => template("${module_name}/autosign.conf.erb"),
     }
   }
 

--- a/spec/classes/puppet_server_config_spec.rb
+++ b/spec/classes/puppet_server_config_spec.rb
@@ -136,7 +136,7 @@ describe 'puppet::server::config', :type => :class do
     end
 
     context 'with autosign' do
-      let(:pre_condition) { 'class { "puppet": server => true, autosign => true, autosign_method => 'file', autosign_file => '/etc/puppetlabs/puppet/autosign.conf'", autosign_white_list =>['foo.example.com'] } ' }
+      let(:pre_condition) { 'class { "puppet": server => true, autosign => true, autosign_method => "file", autosign_file => "/etc/puppetlabs/puppet/autosign.conf", autosign_white_list =>["foo.example.com"] } ' }
       it { should contain_file('/etc/puppetlabs/puppet/autosign.conf').with(:content => /foo\.example\.com/) }
     end
   end

--- a/spec/classes/puppet_server_config_spec.rb
+++ b/spec/classes/puppet_server_config_spec.rb
@@ -134,6 +134,11 @@ describe 'puppet::server::config', :type => :class do
       let(:pre_condition) { 'class { "puppet": server => true, server_ssl_crl_path => "/example/path" } ' }
       it { should contain_file('/etc/puppetlabs/puppetserver/conf.d/webserver.conf').with(:content => /\/example\/path/) }
     end
+
+    context 'with autosign' do
+      let(:pre_condition) { 'class { "puppet": server => true, autosign => true, autosign_method => 'file', autosign_file => '/etc/puppetlabs/puppet/autosign.conf'", autosign_white_list =>['foo.example.com'] } ' }
+      it { should contain_file('/etc/puppetlabs/puppet/autosign.conf').with(:content => /foo\.example\.com/) }
+    end
   end
 
 end

--- a/spec/classes/puppet_server_config_spec.rb
+++ b/spec/classes/puppet_server_config_spec.rb
@@ -136,7 +136,7 @@ describe 'puppet::server::config', :type => :class do
     end
 
     context 'with autosign' do
-      let(:pre_condition) { 'class { "puppet": server => true, autosign => true, autosign_method => "file", autosign_file => "/etc/puppetlabs/puppet/autosign.conf", autosign_white_list =>["foo.example.com"] } ' }
+      let(:pre_condition) { 'class { "puppet": server => true, autosign => true, autosign_method => "file", autosign_file => "/etc/puppetlabs/puppet/autosign.conf", autosign_white_list => ["foo.example.com"] } ' }
       it { should contain_file('/etc/puppetlabs/puppet/autosign.conf').with(:content => /foo\.example\.com/) }
     end
   end

--- a/templates/autosign.conf.erb
+++ b/templates/autosign.conf.erb
@@ -1,3 +1,3 @@
-<% @autosign_white_list.each { |domain| 
+<% @autosign_white_list.each do |domain| -%>
 <%= domain %>
--%>
+<% end -%>

--- a/templates/autosign.conf.erb
+++ b/templates/autosign.conf.erb
@@ -1,0 +1,3 @@
+<% @autosign_white_list.each { |domain| 
+<%= domain %>
+-%>

--- a/templates/puppet.master.erb
+++ b/templates/puppet.master.erb
@@ -17,6 +17,9 @@
 <% end -%>
 
 <% if @autosign -%>
+  #
+  # Basic file autosign support 
+  #
   autosign_method = 'file'
   autosign_file = <%= @autosign_file %>
 <% end -%>

--- a/templates/puppet.master.erb
+++ b/templates/puppet.master.erb
@@ -15,3 +15,8 @@
   storeconfigs = true
   storeconfigs_backend = puppetdb
 <% end -%>
+
+<% if @autosign -%>
+  autosign_method = 'file'
+  autosign_file = <%= @autosign_file %>
+<% end -%>


### PR DESCRIPTION
This is a ulta-simple approach to support the autosign feature of puppet server, based on a file that contains a list of trusted domains 